### PR TITLE
2304 link previous nomination threads

### DIFF
--- a/bot/exts/recruitment/talentpool/_api.py
+++ b/bot/exts/recruitment/talentpool/_api.py
@@ -23,6 +23,7 @@ class Nomination(BaseModel):
     ended_at: datetime | None
     entries: list[NominationEntry]
     reviewed: bool
+    thread_id: int | None
 
 
 class NominationAPI:
@@ -65,6 +66,7 @@ class NominationAPI:
         end_reason: str | None = None,
         active: bool | None = None,
         reviewed: bool | None = None,
+        thread_id: int | None = None,
     ) -> Nomination:
         """
         Edit a nomination.
@@ -78,6 +80,8 @@ class NominationAPI:
             data["active"] = active
         if reviewed is not None:
             data["reviewed"] = reviewed
+        if thread_id is not None:
+            data["thread_id"] = thread_id
 
         result = await self.site_api.patch(f"bot/nominations/{nomination_id}", json=data)
         return Nomination.parse_obj(result)

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -489,6 +489,12 @@ class TalentPool(Cog, name="Talentpool"):
         entries_string = "\n\n".join(entries)
 
         start_date = time.discord_timestamp(nomination.inserted_at)
+        thread = await self.bot.fetch_channel(nomination.thread_id)
+        if thread:
+            thread_mention = thread.mention
+        else:
+            thread_mention = "Thread hasn't been created yet or has been deleted"
+
         if nomination.active:
             lines = textwrap.dedent(
                 f"""
@@ -496,6 +502,7 @@ class TalentPool(Cog, name="Talentpool"):
                 Status: **Active**
                 Date: {start_date}
                 Nomination ID: `{nomination.id}`
+                Nomination vote thread: {thread_mention}
 
                 {entries_string}
                 ===============
@@ -509,6 +516,7 @@ class TalentPool(Cog, name="Talentpool"):
                 Status: Inactive
                 Date: {start_date}
                 Nomination ID: `{nomination.id}`
+                Nomination vote thread: {thread_mention}
 
                 {entries_string}
 

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -17,6 +17,7 @@ from bot.exts.recruitment.talentpool._review import Reviewer
 from bot.log import get_logger
 from bot.pagination import LinePaginator
 from bot.utils import time
+from bot.utils.channel import get_or_fetch_channel
 from bot.utils.members import get_or_fetch_member
 
 from ._api import Nomination, NominationAPI
@@ -490,11 +491,12 @@ class TalentPool(Cog, name="Talentpool"):
 
         start_date = time.discord_timestamp(nomination.inserted_at)
 
+        thread = None
+
         if nomination.thread_id:
-            thread = await self.bot.fetch_channel(nomination.thread_id)
-            thread_jump_url = f'[Jump to thread!]({thread.jump_url})'
-        else:
-            thread_jump_url = "**Thread hasn't been created yet or has been deleted**"
+            thread = await get_or_fetch_channel(nomination.thread_id)
+
+        thread_jump_url = f'[Jump to thread!]({thread.jump_url})' if thread else "*Not created*"
 
         if nomination.active:
             lines = textwrap.dedent(

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -489,11 +489,12 @@ class TalentPool(Cog, name="Talentpool"):
         entries_string = "\n\n".join(entries)
 
         start_date = time.discord_timestamp(nomination.inserted_at)
-        thread = await self.bot.fetch_channel(nomination.thread_id)
-        if thread:
-            thread_mention = thread.mention
+
+        if nomination.thread_id:
+            thread = await self.bot.fetch_channel(nomination.thread_id)
+            thread_jump_url = f'[Jump to thread!]({thread.jump_url})'
         else:
-            thread_mention = "Thread hasn't been created yet or has been deleted"
+            thread_jump_url = "Thread hasn't been created yet or has been deleted"
 
         if nomination.active:
             lines = textwrap.dedent(
@@ -502,7 +503,7 @@ class TalentPool(Cog, name="Talentpool"):
                 Status: **Active**
                 Date: {start_date}
                 Nomination ID: `{nomination.id}`
-                Nomination vote thread: {thread_mention}
+                Nomination vote thread: {thread_jump_url}
 
                 {entries_string}
                 ===============
@@ -516,7 +517,7 @@ class TalentPool(Cog, name="Talentpool"):
                 Status: Inactive
                 Date: {start_date}
                 Nomination ID: `{nomination.id}`
-                Nomination vote thread: {thread_mention}
+                Nomination vote thread: {thread_jump_url}
 
                 {entries_string}
 

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -491,12 +491,15 @@ class TalentPool(Cog, name="Talentpool"):
 
         start_date = time.discord_timestamp(nomination.inserted_at)
 
-        thread = None
+        thread_jump_url = "*Not created*"
 
         if nomination.thread_id:
-            thread = await get_or_fetch_channel(nomination.thread_id)
-
-        thread_jump_url = f'[Jump to thread!]({thread.jump_url})' if thread else "*Not created*"
+            try:
+                thread = await get_or_fetch_channel(nomination.thread_id)
+            except discord.HTTPException:
+                thread_jump_url = "*Not found*"
+            else:
+                thread_jump_url = f'[Jump to thread!]({thread.jump_url})'
 
         if nomination.active:
             lines = textwrap.dedent(

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -494,7 +494,7 @@ class TalentPool(Cog, name="Talentpool"):
             thread = await self.bot.fetch_channel(nomination.thread_id)
             thread_jump_url = f'[Jump to thread!]({thread.jump_url})'
         else:
-            thread_jump_url = "Thread hasn't been created yet or has been deleted"
+            thread_jump_url = "**Thread hasn't been created yet or has been deleted**"
 
         if nomination.active:
             lines = textwrap.dedent(

--- a/bot/exts/recruitment/talentpool/_review.py
+++ b/bot/exts/recruitment/talentpool/_review.py
@@ -180,7 +180,7 @@ class Reviewer:
         )
         message = await thread.send(f"<@&{Roles.mod_team}> <@&{Roles.admins}>")
 
-        await self.api.edit_nomination(nomination.id, reviewed=True)
+        await self.api.edit_nomination(nomination.id, reviewed=True, thread_id=thread.id)
 
         bump_cog: ThreadBumper = self.bot.get_cog("ThreadBumper")
         if bump_cog:
@@ -433,11 +433,15 @@ class Reviewer:
 
         nomination_times = f"{num_entries} times" if num_entries > 1 else "once"
         rejection_times = f"{len(history)} times" if len(history) > 1 else "once"
+        nomination_vote_threads = ", ".join(
+            [f"<#{nomination.thread_id}>" if nomination.thread_id else '' for nomination in history]
+        )
         end_time = time.format_relative(history[0].ended_at)
 
         review = (
             f"They were nominated **{nomination_times}** before"
             f", but their nomination was called off **{rejection_times}**."
+            f"\nList of all of their nomination threads: {nomination_vote_threads}"
             f"\nThe last one ended {end_time} with the reason: {history[0].end_reason}"
         )
 

--- a/bot/exts/recruitment/talentpool/_review.py
+++ b/bot/exts/recruitment/talentpool/_review.py
@@ -16,6 +16,7 @@ from bot.constants import Channels, Colours, Emojis, Guild, Roles
 from bot.exts.recruitment.talentpool._api import Nomination, NominationAPI
 from bot.log import get_logger
 from bot.utils import time
+from bot.utils.channel import get_or_fetch_channel
 from bot.utils.members import get_or_fetch_member
 from bot.utils.messages import count_unique_users_reaction, pin_no_system_message
 
@@ -433,8 +434,13 @@ class Reviewer:
 
         nomination_times = f"{num_entries} times" if num_entries > 1 else "once"
         rejection_times = f"{len(history)} times" if len(history) > 1 else "once"
+        threads = [await get_or_fetch_channel(nomination.thread_id) for nomination in history]
+
         nomination_vote_threads = ", ".join(
-            [f"<#{nomination.thread_id}>" if nomination.thread_id else '' for nomination in history]
+            [
+                f"[Thread-{thread_number}]({thread.jump_url})" if thread else ''
+                for thread_number, thread in enumerate(threads, start=1)
+            ]
         )
         end_time = time.format_relative(history[0].ended_at)
 

--- a/bot/exts/recruitment/talentpool/_review.py
+++ b/bot/exts/recruitment/talentpool/_review.py
@@ -438,6 +438,8 @@ class Reviewer:
         thread_jump_urls = []
 
         for nomination in history:
+            if nomination.thread_id is None:
+                continue
             try:
                 thread = await get_or_fetch_channel(nomination.thread_id)
             except discord.HTTPException:

--- a/bot/exts/recruitment/talentpool/_review.py
+++ b/bot/exts/recruitment/talentpool/_review.py
@@ -449,13 +449,7 @@ class Reviewer:
         if not thread_jump_urls:
             nomination_vote_threads = "No nomination threads have been found for this user."
         else:
-            nomination_vote_threads = ", ".join(
-                [
-                    f"[Thread-{thread_number}]({thread_jump_url})"
-                    for thread_number, thread_jump_url in enumerate(thread_jump_urls, start=1)
-                    if thread_jump_url
-                ]
-            )
+            nomination_vote_threads = ", ".join(thread_jump_urls)
 
         end_time = time.format_relative(history[0].ended_at)
 


### PR DESCRIPTION

The idea is to fetch active nominations that are more than 2 weeks old, and create admin issues for them in Github so that staff will do the follow up.

As soon as a vote is tracked, we add a "🎫" reaction (which can change) to it to make sure we don't create duplicate issues for it, instead of keeping track in another way