### PR TITLE
2226 track old votes in GitHub

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -697,6 +697,14 @@ class VideoPermission(metaclass=YAMLGetter):
     default_permission_duration: int
 
 
+class GithubAdminRepo(metaclass=YAMLGetter):
+    section = "github_admin_repo"
+
+    owner: str
+    name: str
+    token: str
+
+
 class ThreadArchiveTimes(Enum):
     HOUR = 60
     DAY = 1440

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -24,7 +24,7 @@ from bot.utils.members import get_or_fetch_member
 from ._api import Nomination, NominationAPI
 
 AUTOREVIEW_ENABLED_KEY = "autoreview_enabled"
-FLAG_EMOJI = "🚩"
+FLAG_EMOJI = "🎫"
 REASON_MAX_CHARS = 1000
 OLD_NOMINATIONS_THRESHOLD_IN_DAYS = 14
 

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -1,7 +1,8 @@
 import asyncio
 import textwrap
+from datetime import datetime
 from io import StringIO
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import discord
 from async_rediscache import RedisCache
@@ -115,11 +116,20 @@ class TalentPool(Cog, name="Talentpool"):
     @tasks.loop(seconds=30)
     async def track_forgotten_nominations(self) -> None:
         """Track active nominations who are more than 2 weeks old."""
-        # 1. Fetch all active nominations that are more than 2 weeks old from site
         # 2. Run checks on whether they've already been tracked or not
         # 3. Create GitHub task
         # 4. Add emojis
         return
+
+    async def _get_forgotten_nominations(self) -> List[Nomination]:
+        """Get active nominations that are more than 2 weeks old."""
+        now = datetime.utcnow()
+        nominations = [
+            nomination
+            for nomination in await self.api.get_nominations(active=True)
+            if (now - nomination.inserted_at).days >= OLD_NOMINATIONS_THRESHOLD_IN_DAYS
+        ]
+        return nominations
 
     @tasks.loop(hours=1)
     async def autoreview_loop(self) -> None:

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -120,11 +120,10 @@ class TalentPool(Cog, name="Talentpool"):
     async def track_forgotten_nominations(self) -> None:
         """Track active nominations who are more than 2 weeks old."""
         old_nominations = await self._get_forgotten_nominations()
-        await self._filter_out_tracked_nominations(old_nominations)
-        # 2. Run checks on whether they've already been tracked or not
-        # 3. Create GitHub task
-        # 4. Add emojis
-        return
+        nomination_details = await self._filter_out_tracked_nominations(old_nominations)
+        for nomination, nomination_vote_message in nomination_details:
+            await self._track_vote_in_github(nomination)
+            await nomination_vote_message.add_reaction(FLAG_EMOJI)
 
     async def _get_forgotten_nominations(self) -> List[Nomination]:
         """Get active nominations that are more than 2 weeks old."""
@@ -169,7 +168,11 @@ class TalentPool(Cog, name="Talentpool"):
             untracked_nominations.append((nomination, starter_message))
         return untracked_nominations
 
-    @tasks.loop(hours=1)
+    async def _track_vote_in_github(self, nomination: Nomination) -> None:
+        """Adds an issue in GitHub to track dormant vote."""
+        return
+
+    @tasks.loop(seconds=10)
     async def autoreview_loop(self) -> None:
         """Send request to `reviewer` to send a nomination if ready."""
         if not await self.autoreview_enabled():

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -118,7 +118,7 @@ class TalentPool(Cog, name="Talentpool"):
         else:
             await ctx.send("Autoreview is currently disabled.")
 
-    @tasks.loop(seconds=5)
+    @tasks.loop(hours=72)
     async def track_forgotten_nominations(self) -> None:
         """Track active nominations who are more than 2 weeks old."""
         old_nominations = await self._get_forgotten_nominations()
@@ -193,7 +193,7 @@ class TalentPool(Cog, name="Talentpool"):
             # REVIEW: Might be useful to add logs here ?
             return response.status == 201
 
-    @tasks.loop(seconds=10)
+    @tasks.loop(hours=1)
     async def autoreview_loop(self) -> None:
         """Send request to `reviewer` to send a nomination if ready."""
         if not await self.autoreview_enabled():

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -122,8 +122,8 @@ class TalentPool(Cog, name="Talentpool"):
     async def track_forgotten_nominations(self) -> None:
         """Track active nominations who are more than 2 weeks old."""
         old_nominations = await self._get_forgotten_nominations()
-        nomination_details = await self._filter_out_tracked_nominations(old_nominations)
-        for nomination, nomination_vote_message in nomination_details:
+        untracked_nominations = await self._find_untracked_nominations(old_nominations)
+        for nomination, nomination_vote_message in untracked_nominations:
             issue_created = await self._track_vote_in_github(nomination)
             if issue_created:
                 await nomination_vote_message.add_reaction(FLAG_EMOJI)
@@ -138,11 +138,16 @@ class TalentPool(Cog, name="Talentpool"):
         ]
         return nominations
 
-    async def _filter_out_tracked_nominations(
+    async def _find_untracked_nominations(
             self,
             nominations: list[Nomination]
     ) -> list[Tuple[Nomination, discord.Message]]:
-        """Filter the forgotten nominations that are still untracked in GitHub."""
+        """
+        Returns a list of tuples representing a nomination and its vote message.
+
+        All active nominations are iterated over to identify whether they're tracked or not
+        by checking whether the nomination message has the "🎫" emoji or not
+        """
         untracked_nominations = []
 
         for nomination in nominations:

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -179,7 +179,7 @@ class TalentPool(Cog, name="Talentpool"):
         Returns True when the issue has been created, False otherwise.
         """
         if not GithubAdminRepo.token:
-            log.warn(f"No token for the {GithubAdminRepo.name} repository was provided, skipping issue creation.")
+            log.warning(f"No token for the {GithubAdminRepo.name} repository was provided, skipping issue creation.")
             return False
 
         url = f"https://api.github.com/repos/{GithubAdminRepo.owner}/{GithubAdminRepo.name}/issues"

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -1,7 +1,7 @@
 import asyncio
 import textwrap
 from io import StringIO
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 import arrow
 import discord
@@ -128,7 +128,7 @@ class TalentPool(Cog, name="Talentpool"):
             if issue_created:
                 await nomination_vote_message.add_reaction(FLAG_EMOJI)
 
-    async def _get_forgotten_nominations(self) -> List[Nomination]:
+    async def _get_forgotten_nominations(self) -> list[Nomination]:
         """Get active nominations that are more than 2 weeks old."""
         now = arrow.utcnow()
         nominations = [
@@ -140,8 +140,8 @@ class TalentPool(Cog, name="Talentpool"):
 
     async def _filter_out_tracked_nominations(
             self,
-            nominations: List[Nomination]
-    ) -> List[Tuple[Nomination, discord.Message]]:
+            nominations: list[Nomination]
+    ) -> list[Tuple[Nomination, discord.Message]]:
         """Filter the forgotten nominations that are still untracked in GitHub."""
         untracked_nominations = []
 

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -190,7 +190,7 @@ class TalentPool(Cog, name="Talentpool"):
         data = {"title": f"Nomination review needed. Id: {nomination.id}. User: {member.name}"}
 
         async with self.bot.http_session.post(url=url, raise_for_status=True, headers=headers, json=data) as response:
-            # REVIEW: Might be useful to add logs here ?
+            log.debug(f"Creating a review reminder issue for user {member.name}")
             return response.status == 201
 
     @tasks.loop(hours=1)

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -23,6 +23,7 @@ from ._api import Nomination, NominationAPI
 
 AUTOREVIEW_ENABLED_KEY = "autoreview_enabled"
 REASON_MAX_CHARS = 1000
+OLD_NOMINATIONS_THRESHOLD_IN_DAYS = 14
 
 log = get_logger(__name__)
 
@@ -110,6 +111,15 @@ class TalentPool(Cog, name="Talentpool"):
             await ctx.send("Autoreview is currently enabled.")
         else:
             await ctx.send("Autoreview is currently disabled.")
+
+    @tasks.loop(seconds=30)
+    async def track_forgotten_nominations(self) -> None:
+        """Track active nominations who are more than 2 weeks old."""
+        # 1. Fetch all active nominations that are more than 2 weeks old from site
+        # 2. Run checks on whether they've already been tracked or not
+        # 3. Create GitHub task
+        # 4. Add emojis
+        return
 
     @tasks.loop(hours=1)
     async def autoreview_loop(self) -> None:

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -1,7 +1,7 @@
 import asyncio
 import textwrap
 from io import StringIO
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 import arrow
 import discord
@@ -136,7 +136,10 @@ class TalentPool(Cog, name="Talentpool"):
         ]
         return nominations
 
-    async def _filter_out_tracked_nominations(self, nominations: List[Nomination]) -> List[Nomination]:
+    async def _filter_out_tracked_nominations(
+            self,
+            nominations: List[Nomination]
+    ) -> List[Tuple[Nomination, discord.Message]]:
         """Filter the forgotten nominations that are still untracked in GitHub."""
         untracked_nominations = []
 
@@ -163,8 +166,7 @@ class TalentPool(Cog, name="Talentpool"):
                 # Nomination has been already tracked in GitHub
                 continue
 
-            untracked_nominations.append(nomination)
-
+            untracked_nominations.append((nomination, starter_message))
         return untracked_nominations
 
     @tasks.loop(hours=1)

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -187,6 +187,10 @@ class TalentPool(Cog, name="Talentpool"):
             "Authorization": f"Bearer {GithubAdminRepo.token}"
         }
         member = await get_or_fetch_member(self.bot.get_guild(Guild.id), nomination.user_id)
+        if not member:
+            log.debug(f"Couldn't find member: {nomination.user_id}")
+            return False
+
         data = {"title": f"Nomination review needed. Id: {nomination.id}. User: {member.name}"}
 
         async with self.bot.http_session.post(url=url, raise_for_status=True, headers=headers, json=data) as response:

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -150,9 +150,10 @@ class TalentPool(Cog, name="Talentpool"):
             if not nomination.thread_id:
                 continue
 
-            thread = await get_or_fetch_channel(nomination.thread_id)
-            if not thread:
-                # Thread was deleted
+            try:
+                thread = await get_or_fetch_channel(nomination.thread_id)
+            except discord.NotFound:
+                log.debug(f"Couldn't find thread {nomination.thread_id}")
                 continue
 
             starter_message = thread.starter_message

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -159,11 +159,11 @@ class TalentPool(Cog, name="Talentpool"):
             starter_message = thread.starter_message
             if not starter_message:
                 # Starter message will be null if it's not cached
-                starter_message = await self.bot.get_channel(Channels.nomination_voting).fetch_message(thread.id)
-
-            if not starter_message:
-                # Starter message deleted
-                continue
+                try:
+                    starter_message = await self.bot.get_channel(Channels.nomination_voting).fetch_message(thread.id)
+                except discord.NotFound:
+                    log.debug(f"Couldn't find message {thread.id} in channel: {Channels.nomination_voting}")
+                    continue
 
             if FLAG_EMOJI in [reaction.emoji for reaction in starter_message.reactions]:
                 # Nomination has been already tracked in GitHub

--- a/bot/resources/tags/customcooldown.md
+++ b/bot/resources/tags/customcooldown.md
@@ -17,4 +17,4 @@ async def on_message(message):
         await message.channel.send("Not ratelimited!")
 ```
 
-`from_cooldown` takes the amount of `update_rate_limit()`s needed to trigger the cooldown, the time in which the cooldown is triggered, and a [`BucketType`](https://discordpy.readthedocs.io/en/stable/ext/commands/api.html#discord.discord.ext.commands.BucketType).
+`from_cooldown` takes the amount of `update_rate_limit()`s needed to trigger the cooldown, the time in which the cooldown is triggered, and a [`BucketType`](https://discordpy.readthedocs.io/en/stable/ext/commands/api.html#discord.ext.commands.BucketType).

--- a/bot/resources/tags/customcooldown.md
+++ b/bot/resources/tags/customcooldown.md
@@ -17,4 +17,4 @@ async def on_message(message):
         await message.channel.send("Not ratelimited!")
 ```
 
-`from_cooldown` takes the amount of `update_rate_limit()`s needed to trigger the cooldown, the time in which the cooldown is triggered, and a [`BucketType`](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#discord.discord.ext.commands.BucketType).
+`from_cooldown` takes the amount of `update_rate_limit()`s needed to trigger the cooldown, the time in which the cooldown is triggered, and a [`BucketType`](https://discordpy.readthedocs.io/en/stable/ext/commands/api.html#discord.discord.ext.commands.BucketType).

--- a/bot/resources/tags/intents.md
+++ b/bot/resources/tags/intents.md
@@ -16,4 +16,4 @@ intents.members = True
 bot = commands.Bot(command_prefix="!", intents=intents)
 ```
 
-For more info about using intents, see the [discord.py docs on intents](https://discordpy.readthedocs.io/en/latest/intents.html), and for general information about them, see the [Discord developer documentation on intents](https://discord.com/developers/docs/topics/gateway#gateway-intents).
+For more info about using intents, see the [discord.py docs on intents](https://discordpy.readthedocs.io/en/stable/intents.html), and for general information about them, see the [Discord developer documentation on intents](https://discord.com/developers/docs/topics/gateway#gateway-intents).

--- a/bot/resources/tags/local-file.md
+++ b/bot/resources/tags/local-file.md
@@ -1,4 +1,4 @@
-Thanks to discord.py, sending local files as embed images is simple. You have to create an instance of [`discord.File`](https://discordpy.readthedocs.io/en/latest/api.html#discord.File) class:
+Thanks to discord.py, sending local files as embed images is simple. You have to create an instance of [`discord.File`](https://discordpy.readthedocs.io/en/stable/api.html#discord.File) class:
 ```py
 # When you know the file exact path, you can pass it.
 file = discord.File("/this/is/path/to/my/file.png", filename="file.png")
@@ -10,7 +10,7 @@ with open("/this/is/path/to/my/file.png", "rb") as f:
 When using the file-like object, you have to open it in `rb` mode. Also, in this case, passing `filename` to it is not necessary.
 Please note that `filename` can't contain underscores. This is a Discord limitation.
 
-[`discord.Embed`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed) instances have a [`set_image`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed.set_image) method which can be used to set an attachment as an image:
+[`discord.Embed`](https://discordpy.readthedocs.io/en/stable/api.html#discord.Embed) instances have a [`set_image`](https://discordpy.readthedocs.io/en/stable/api.html#discord.Embed.set_image) method which can be used to set an attachment as an image:
 ```py
 embed = discord.Embed()
 # Set other fields
@@ -20,4 +20,4 @@ After this, you can send an embed with an attachment to Discord:
 ```py
 await channel.send(file=file, embed=embed)
 ```
-This example uses [`discord.TextChannel`](https://discordpy.readthedocs.io/en/latest/api.html#discord.TextChannel) for sending, but any instance of [`discord.abc.Messageable`](https://discordpy.readthedocs.io/en/latest/api.html#discord.abc.Messageable) can be used for sending.
+This example uses [`discord.TextChannel`](https://discordpy.readthedocs.io/en/stable/api.html#discord.TextChannel) for sending, but any instance of [`discord.abc.Messageable`](https://discordpy.readthedocs.io/en/stable/api.html#discord.abc.Messageable) can be used for sending.

--- a/config-default.yml
+++ b/config-default.yml
@@ -587,5 +587,5 @@ video_permission:
 
 github_admin_repo:
     owner: 'python-discord'
-    name: 'admin'
+    name: 'admin-tasks'
     token: !ENV ["ADMIN_GITHUB_REPO_TOKEN", ""]

--- a/config-default.yml
+++ b/config-default.yml
@@ -574,7 +574,7 @@ voice_gate:
 
 
 branding:
-    cycle_frequency: 3  # How many days bot wait before refreshing server icon
+    cycle_frequency: 3  # How many days the bot waits before refreshing server icon
 
 
 config:
@@ -583,3 +583,9 @@ config:
 
 video_permission:
     default_permission_duration: 5  # Default duration for stream command in minutes
+
+
+github_admin_repo:
+    owner: 'python-discord'
+    name: 'admin'
+    token: !ENV ["ADMIN_GITHUB_REPO_TOKEN", ""]


### PR DESCRIPTION


The idea is to fetch active nominations that are more than 2 weeks old, and create admin issues for them in Github so that staff will do the follow up.

As soon as a vote is tracked, we add a "🎫" reaction (which can change) to it to make sure we don't create duplicate issues for it, instead of keeping track in another way